### PR TITLE
Publish-steps bugfix

### DIFF
--- a/class/Bidragsytere.php
+++ b/class/Bidragsytere.php
@@ -20,7 +20,10 @@ class Bidragsytere {
 			return false;
 
 		// Dersom keyen finnes slår vi sammen teksten
-		if ( null != $this->bidragsyterListe[$loginName] && $append) {
+		if ( null != $this->bidragsyterListe[$loginName] 
+			&& $append 
+			&& $role != $this->bidragsyterListe[$loginName] 
+		) {
 			$role = $this->bidragsyterListe[$loginName].', '.$role;
 		}
 		$this->bidragsyterListe[$loginName] = $role;

--- a/tweak.multiauthor.php
+++ b/tweak.multiauthor.php
@@ -28,6 +28,7 @@ function ukm_multiauthor() {
 	// Hvis dette er en slett-request
 	if(isset($_GET['ukm_ma_fjern'])) {
 		$bidragsytere->fjern($_GET['ukm_ma_fjern']);
+		$bidragsytere->lagre();
 	}
 
 	if($bidragsytere->har()) {
@@ -86,14 +87,5 @@ function UKMwpat_ma_save($post_id) {
 		$bidragsytere->leggTil($_POST['ukm_ma_author'], $_POST['ukm_ma_role']);
 		$bidragsytere->lagre();
 	}
-	return true;
-}
-
-function UKMwpat_ma_fjern($author) {
-	global $post;
-
-	$bidragsytere = new Bidragsytere($post->ID);
-	$bidragsytere->fjern($author);
-
 	return true;
 }

--- a/tweak.post-layout.php
+++ b/tweak.post-layout.php
@@ -11,7 +11,6 @@ function UKMwpat_add_layout_meta_box() {
 function ukm_post_layout() {
 	require_once('UKM/form.class.php');
 	global $post;
-	#var_dump($post);
 
 	// Finn current meta-tag
 	$meta = get_post_meta($post->ID, 'UKM_block');
@@ -41,6 +40,11 @@ function ukm_post_layout() {
 
 	echo $select;	
 
+	// Hvis vi har et bilde, vis det her
+	if( in_array($meta, array("image_left", "image_right", "lead", "lead_center")) ) {
+		echo '<image src="'.$ukm_image_xs.'" id="ukm_post_layout_image" style="width: 100%"/>';
+	}
+
 	$key = get_post_meta($post->ID, "UKM_nav_menu", true);
 	ukm_post_layout_selectMenu($key, $meta == "sidemedmeny");
 	ukm_post_layout_imageButton();
@@ -53,17 +57,18 @@ function ukm_post_layout() {
 	echo '<div class="clearfix"></div>';
 	echo '</div>';
 
+	echo '<script>jQuery( window ).on( "load", function() { jQuery("#ukm_post_layout_style").change() });</script>';
+
 	return $select;
 }
 
 function ukm_post_layout_imageButton() {
 	echo '<div id="imageStuff" class="hidden">';
 	$img = '<img style="width: 100%;" id="ukm_post_layout_image" src="'. ( $ukm_image_lg ? $ukm_image_lg : '').'">';
-	#$imgURL = '<input type="hidden" id="ukm_post_layout_image_url" value="'. ( $ukm_image_lg ? $ukm_image_lg : '' ).'">';
 	$att = '<input type="hidden" name="ukm_post_layout_attachment" id="ukm_post_layout_attachment" value="'. ($att ? $att : '').'">';
 	echo $img;
-	#echo $imgURL;
 	echo $att;
+	
 	wp_enqueue_script('UKMMonstring_script',  plugin_dir_url( __FILE__ )  . 'js/monstring.script.js' );
 	wp_enqueue_script('UKMtemplate_script',  plugin_dir_url( __FILE__ )  . 'js/templateSelect.script.js' );
 

--- a/tweak.post-recommendedfields.php
+++ b/tweak.post-recommendedfields.php
@@ -118,7 +118,12 @@ function UKMwpat_req_save() {
 	}
 
 	// Contributors - ukm_ma-fancy stuff
-	if ( in_array("bidragsytere", $fields) && !empty($_POST['rolle']) ) {
+	if ( 
+		in_array("bidragsytere", $fields) 
+		&& !empty($_POST['rolle']) 
+		&& !empty($_POST['loginName']) 
+		&& $_POST['loginName'] != "disabled" ) 
+	{
 		require_once('class/Bidragsytere.php');
 		$bidragsytere = new Bidragsytere($postID);
 

--- a/tweak.post-recommendedfields.php
+++ b/tweak.post-recommendedfields.php
@@ -22,6 +22,10 @@ function UKMwpat_req_script() {
 // Skal sjekke om all informasjon vi vil ha er på plass, 
 // og hvis ikke redirecte oss til en ny side der vi kan fylle inn den manglende informasjonen.
 function UKMwpat_req_hook( $ID, $post ) {
+	// Skip if the post is not a post.
+	if ('post' != get_post_type($post)) {
+		return;
+	}
 	require_once('class/Bidragsytere.php');
 	$user = wp_get_current_user();
 	$bidragsytere = new Bidragsytere($post->ID);

--- a/tweak.post-recommendedfields.php
+++ b/tweak.post-recommendedfields.php
@@ -22,7 +22,7 @@ function UKMwpat_req_script() {
 // Skal sjekke om all informasjon vi vil ha er på plass, 
 // og hvis ikke redirecte oss til en ny side der vi kan fylle inn den manglende informasjonen.
 function UKMwpat_req_hook( $ID, $post ) {
-	// Skip if the post is not a post.
+	// Kun gjør noe om dette er en post.
 	if ('post' != get_post_type($post)) {
 		return;
 	}

--- a/tweak.post-recommendedfields.php
+++ b/tweak.post-recommendedfields.php
@@ -23,7 +23,7 @@ function UKMwpat_req_script() {
 // og hvis ikke redirecte oss til en ny side der vi kan fylle inn den manglende informasjonen.
 function UKMwpat_req_hook( $ID, $post ) {
 	// Kun gjør noe om dette er en post.
-	if ('post' != get_post_type($post)) {
+	if ('post' != get_post_type($post) || 'publish' != get_post_status($post->ID)) {
 		return;
 	}
 	require_once('class/Bidragsytere.php');
@@ -31,8 +31,8 @@ function UKMwpat_req_hook( $ID, $post ) {
 	$bidragsytere = new Bidragsytere($post->ID);
 	if ( $bidragsytere->burdeHa() && $bidragsytere->harIkke() 
 		|| !has_post_thumbnail($post->ID)
-		|| !hasPostType($post->ID) )
-	{
+		|| (!hasPostType($post->ID) && shouldHavePostTypeAndMentions())
+	) {
 		$newURL = "admin.php?page=recommendedfields&id=".$post->ID;
 		header('Location: '. $newURL);
 		die();
@@ -75,7 +75,6 @@ function UKMwpat_req_render() {
 	$TWIGdata['bildePreview'] = '';
 
 	// Sjekk om vi mangler bidragsytere:
-
 	$TWIGdata['shouldHaveContributors'] = $bidragsytere->burdeHa();
 	$TWIGdata['missingContributors'] = $bidragsytere->harIkke();
 	$TWIGdata['contributorList'] = $bidragsytere->alleMulige();
@@ -152,6 +151,14 @@ function UKMwpat_req_save() {
 	}
 
 	return $output;
+}
+
+// Skal ikke ha posttype eller artistnavn på nasjonal-side.
+function shouldHavePostTypeAndMentions() {
+	if( false != get_option('site_type') ) {
+		return true;
+	}
+	return false;
 }
 
 function hasPostType($postID) {

--- a/twig/recommendedfields.html.twig
+++ b/twig/recommendedfields.html.twig
@@ -30,7 +30,7 @@
 				<div class="" id="bidragsyterListe"></div>
 				<div class="form-inline">
 					<select id="nyPerson" class="form-control">
-						<option disabled selected value="">Velg bidragsyter</option>
+						<option disabled selected value="disabled">Velg bidragsyter</option>
 						{% for bidragsyter in contributorList %}
 							<option value="{{ bidragsyter.data.user_login }}">{{ bidragsyter.data.user_nicename }}</option>
 						{% endfor %}
@@ -111,15 +111,15 @@ jQuery("#leggtilbidragsyter").click(function(knapp) {
 	}
 	/*console.log(rolle);
 	console.log(person);
-	console.log(loginName);*/
+	console.log('login: ' + loginName);*/
 
-	var display = jQuery('<div class="bidragsyter"><div id="personPlaceholder"></div><input type="hidden" name="loginName[]" value="'+loginName+'"><input type="text" name="rolle[]" value="'+rolle+'"/></div>');
+	var display = jQuery('<div class="bidragsyter"><div id="personPlaceholder"></div><input type="hidden" name="loginName[]" value="'+person+'"><input type="text" name="rolle[]" value="'+rolle+'"/></div>');
 	
 	jQuery("#bidragsyterListe").append(display);
 	var select = jQuery("#nyPerson").clone();
 	select = select.attr('name', 'person[]');
 	select = select.removeAttr('id');
-	select.find('option[value="'+loginName+'"]').prop('selected', true);
+	select.find('option[value="'+person+'"]').prop('selected', true);
 	jQuery("#personPlaceholder").replaceWith(select);
 	
 	// Nullstill Legg til-bolken.

--- a/ukmwp_admin-tweaks.php
+++ b/ukmwp_admin-tweaks.php
@@ -83,11 +83,11 @@ if(is_admin()){
 	add_action('add_meta_boxes', 'UKMwpat_add_ma_box');
 	add_action( 'admin_enqueue_scripts', 'UKMwpat_add_ma_styles', 10000 );
 
+	
 	// Stopp publisering og vis spørsmål om vi mangler info
 	add_action('admin_menu', 'UKMwpat_req_menu_hook');
-	add_action('publish_post', 'UKMwpat_req_hook', 10, 2);
+	add_action('save_post', 'UKMwpat_req_hook', 10002, 2);
 	add_action('admin_enqueue_scripts', 'UKMwpat_req_script', 10000 );
-	
 
 	// Layout for festival-lignende sider
 	add_action( 'add_meta_boxes', 'UKMwpat_add_layout_meta_box' );


### PR DESCRIPTION
Testet og OK lokalt hos meg, @mariusmandal.

Kopi fra epost-OK: 
1. Slår kun inn på post_type == post.
2. Video-on-top lagres i egen handler, som før ikke har trigga om recommended_fields slår inn.
Har skrevet om hele save-biten her nå, så video_on_top-lagringen er helt uavhengig av dette. Denne funksjonaliteten trigger nå _etter_ lagring av post, ikke før. Så alle sjekker går på lagret data, og forstyrrer ikke andre ting som vil lagre data.

Har også lagt inn det vi snakka om, med at nasjonalsiden / forsiden ikke skal få omtale-boksen, ettersom det ikke finnes innslag der. Dette er også fikset nå.